### PR TITLE
Observer Crasher

### DIFF
--- a/NCKTextView/Classes/NCKTextView.Toolbar.ex.swift
+++ b/NCKTextView/Classes/NCKTextView.Toolbar.ex.swift
@@ -21,6 +21,16 @@ var nck_formatTableViewController: NCKFormatTableViewController?
 var formatMenuView: UIView?
 
 extension NCKTextView {
+    
+    /**
+     Remove toolbar notifications
+     */
+    
+    public func RemoveToolbarNotifications() {
+        NSNotificationCenter.defaultCenter().removeObserver(self, name: UIKeyboardWillShowNotification, object: nil)
+        NSNotificationCenter.defaultCenter().removeObserver(self, name: UIKeyboardWillHideNotification, object: nil)
+    }
+    
     /**
      Enable the toolbar, binding the show and hide events.
      
@@ -145,6 +155,10 @@ extension NCKTextView {
     
     func keyboardWillShowOrHide(notification: NSNotification) {
         guard let info = notification.userInfo else {
+            return
+        }
+  
+        guard self.superview != nil else {
             return
         }
         

--- a/NCKTextView/Classes/NCKTextView.Toolbar.ex.swift
+++ b/NCKTextView/Classes/NCKTextView.Toolbar.ex.swift
@@ -26,7 +26,7 @@ extension NCKTextView {
      Remove toolbar notifications
      */
     
-    public func RemoveToolbarNotifications() {
+    public func removeToolbarNotifications() {
          NSNotificationCenter.defaultCenter().removeObserver(self)
     }
     

--- a/NCKTextView/Classes/NCKTextView.Toolbar.ex.swift
+++ b/NCKTextView/Classes/NCKTextView.Toolbar.ex.swift
@@ -27,8 +27,7 @@ extension NCKTextView {
      */
     
     public func RemoveToolbarNotifications() {
-        NSNotificationCenter.defaultCenter().removeObserver(self, name: UIKeyboardWillShowNotification, object: nil)
-        NSNotificationCenter.defaultCenter().removeObserver(self, name: UIKeyboardWillHideNotification, object: nil)
+         NSNotificationCenter.defaultCenter().removeObserver(self)
     }
     
     /**

--- a/NCKTextView/Classes/NCKTextView.swift
+++ b/NCKTextView/Classes/NCKTextView.swift
@@ -62,7 +62,7 @@ public class NCKTextView: UITextView, UIGestureRecognizerDelegate {
     }
     
     deinit {
-        self.RemoveToolbarNotifications()
+        self.removeToolbarNotifications()
     }
     
     func customTextView() {

--- a/NCKTextView/Classes/NCKTextView.swift
+++ b/NCKTextView/Classes/NCKTextView.swift
@@ -62,7 +62,7 @@ public class NCKTextView: UITextView, UIGestureRecognizerDelegate {
     }
     
     deinit {
-        NSNotificationCenter.defaultCenter().removeObserver(self)
+        self.RemoveToolbarNotifications()
     }
     
     func customTextView() {


### PR DESCRIPTION
Hello,

Great control. Is a real lifesaver.  When implementing into my app, I found some interesting behavior if NCKTextView controller is on a UIViewController that is opened and closed more than once. 

For example, UITableView with a list of notes, when you click on a cell it opens a note using NCKTextView in a seperate UIViewController.

After the second note is loaded, the app crashes with an optional nil exception. The underlying reason is that deinit is not being called so the observers are still there.  This causes the keyboard notification to fire without the superview being in place yet.

I've added two workarounds for this. Maybe you have a better solution.
1. Added the helper function RemoveToolbarNotifications.  Since the calling controller enables the notifications I figured it should have the ability to remove them.  If you add this statement into the deinit of the host controller this stops the issue.
2. In the keyboardWillShowOrHide  func I've added a guard to make sure the superview is in place. 

```
        guard self.superview != nil else {
            return
        }
```

This stop the error for being generated.

Hopefully this is something helpful or at least raises another use case to consider.
